### PR TITLE
Remove stdafx.h

### DIFF
--- a/stm32mem.c
+++ b/stm32mem.c
@@ -8,7 +8,6 @@
 #include "dfu-bool.h"
 #include "dfu.h"
 #include "stm32mem.h"
-#include "stdafx.h"
 
 
 //___ M A C R O S   ( P R I V A T E ) ________________________________________


### PR DESCRIPTION
This file seems to be autogenerated by Visual Studio? Anyways, this seems to work fine on Linux with the line removed.